### PR TITLE
Fix issue with cache file write race condition

### DIFF
--- a/twitter.js
+++ b/twitter.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 const request = require('request-promise')
 const { promises: fs } = require("fs");
+const syncFs = require('fs')
 
 
 module.exports = {
@@ -268,7 +269,7 @@ async function addTweetToCache(tweet, options) {
         // makre sure directory exists
         await fs.mkdir(cacheDir, {recursive: true})
 
-        await fs.writeFile(cachePath, tweetsJSON)
+        syncFs.writeFileSync(cachePath, tweetsJSON)
 
         console.log(`Writing ${cachePath}`)
     } catch (error) {


### PR DESCRIPTION
Fixes #1 

I don't understand why there's a race condition, because there's an `await` for the call to `writeFile`, but using `writeFileSync` fixes the issue, so there must be something.
