### PR TITLE
Add an auto embed option (replaces #2)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -16,8 +16,8 @@ module.exports = {
         });
 
         if (options.autoEmbed) {
-            eleventyConfig.addTransform("autoEmbedTweets", (content, outputPath) => {
-                return content.replace(/<p><a href="(https:\/\/twitter.com\/[^/]+\/status\/([0-9]+))">\1<\/a><\/p>/g, (match, p1, p2) => `\n${twitter.getTweet(p2, options)}\n`);
+            eleventyConfig.addTransform("autoEmbedTweets", async (content, outputPath) => {
+                return await twitter.autoEmbedTweets(content, outputPath, options)
             });
         }
     }

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,9 +2,9 @@ var twitter = require("./twitter")
 
 module.exports = {
     initArguments: {},
-    configFunction: function(eleventyConfig, {cacheDirectory = "", useInlineStyles = true} = {}) {
+    configFunction: function(eleventyConfig, {cacheDirectory = "", useInlineStyles = true, autoEmbed = false} = {}) {
         // combine destructured option params
-        let options = {cacheDirectory, useInlineStyles}
+        let options = {cacheDirectory, useInlineStyles, autoEmbed}
         
         // added in 0.10.0
         eleventyConfig.addNunjucksAsyncShortcode("tweet", async(tweetId) => {
@@ -15,5 +15,10 @@ module.exports = {
             return await twitter.getStyles()
         });
 
+        if (options.autoEmbed) {
+            eleventyConfig.addTransform("autoEmbedTweets", (content, outputPath) => {
+                return content.replace(/<p><a href="(https:\/\/twitter.com\/[^/]+\/status\/([0-9]+))">\1<\/a><\/p>/g, (match, p1, p2) => `\n${twitter.getTweet(p2, options)}\n`);
+            });
+        }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-embed-tweet",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -453,6 +453,11 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "expand-brackets": {
       "version": "2.1.4",
@@ -1612,6 +1617,11 @@
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -2075,6 +2085,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
+    "string-replace-async": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/string-replace-async/-/string-replace-async-1.2.1.tgz",
+      "integrity": "sha1-1SzcfjOBQbvq6jRx3jEhUCjJo6o=",
+      "requires": {
+        "escape-string-regexp": "^1.0.4",
+        "object-assign": "^4.0.1"
+      }
     },
     "string-width": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "moment": "^2.23.0",
     "nunjucks": "^3.2.0",
     "request": "^2.88.0",
-    "request-promise": "^4.2.5"
+    "request-promise": "^4.2.5",
+    "string-replace-async": "^1.2.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ let pluginEmbedTweet = require("eleventy-plugin-embed-tweet")
 let tweetEmbedOptions = {
     cacheDirectory: '',    // default: ''
     useInlineStyles: true  // default: true
+    autoEmbed: false       // default: false
 }
 
 eleventyConfig.addPlugin(pluginEmbedTweet, tweetEmbedOptions);
@@ -166,6 +167,26 @@ If you'd like to guarantee that the build server is always getting the latest da
     "full-build": "set CACHE_BUST=true && npx eleventy",
     "clear-cache": "rm -rf tweets"
 }
+```
+
+#### `autoEmbed`
+
+This configuration option, if set to `true`, adds a transform to Eleventy to find links to tweets that are "alone" in a paragraph, with the value equal to the URL, and auto embed them, replacing the link.
+
+For example:
+
+```html
+<p><a href="https://twitter.com/KyleMitBTV/status/1211079569245114371">https://twitter.com/KyleMitBTV/status/1211079569245114371</a></p>
+```
+
+Will be replaced by the embedded tweet.
+
+In the source Markdown, it only needs the tweet URL on one single line:
+
+```markdown
+
+https://twitter.com/KyleMitBTV/status/1211079569245114371
+
 ```
 
 ## Performance

--- a/twitter.js
+++ b/twitter.js
@@ -5,7 +5,8 @@ const { promises: fs } = require("fs");
 
 module.exports = {
     getTweet,
-    getStyles
+    getStyles,
+    autoEmbedTweets
 }
 
 async function getTweet(tweetId, options) {
@@ -302,3 +303,14 @@ async function getStyles() {
     return styles
 }
 
+
+// Auto embed tweets
+const asyncReplace = require('string-replace-async')
+
+async function autoEmbedTweets(content, outputPath, options) {
+    return await asyncReplace(
+        content,
+        /<p><a href="(https:\/\/twitter.com\/[^/]+\/status\/([0-9]+))">\1<\/a><\/p>/g,
+        async (match, p1, p2) => await getTweet(p2, options)
+    )
+}


### PR DESCRIPTION
(Following [my mistake](https://github.com/KyleMit/eleventy-plugin-embed-tweet/pull/2#issuecomment-653013062), I chose to create this new clean PR).

This option finds links to tweets that are "alone" in a paragraph, with the value equal to the URL, and auto embed them, replacing the link.

For example:

```html
<p><a href="https://twitter.com/KyleMitBTV/status/1211079569245114371">https://twitter.com/KyleMitBTV/status/1211079569245114371</a></p>
```

This comes from simple Markdown:

```markdown
https://twitter.com/KyleMitBTV/status/1211079569245114371
```

For example, this page:
https://nicolas-hoizey.com/notes/2020/03/12/2/

Comes from this Markdown file:
https://github.com/nhoizey/nicolas-hoizey.com/blob/master/src/notes/2020/03/12/2/index.md
