### PR TITLE
Use 11ty’s Compatibility API

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,5 @@
-var twitter = require("./twitter")
+const pkg = require("./package.json");
+const twitter = require("./twitter")
 
 module.exports = {
     initArguments: {},
@@ -6,6 +7,13 @@ module.exports = {
         // combine destructured option params
         let options = {cacheDirectory, useInlineStyles, autoEmbed}
         
+        try {
+            eleventyConfig.versionCheck(pkg["11ty"].compatibility);
+        } catch (e) {
+            console.log(
+              `WARN: Eleventy Plugin (${pkg.name}) Compatibility: ${e.message}`
+            );
+        }
         // added in 0.10.0
         eleventyConfig.addNunjucksAsyncShortcode("tweet", async(tweetId) => {
             return await twitter.getTweet(tweetId, options)

--- a/package.json
+++ b/package.json
@@ -26,9 +26,6 @@
         "url": "http://kylemit.dev/"
     },
     "license": "MIT",
-    "peerDependencies": {
-        "@11ty/eleventy": ">=0.10.0-beta.1"
-    },
     "dependencies": {
         "dotenv": "^8.2.0",
         "html-minifier": "^4.0.0",
@@ -37,5 +34,8 @@
         "request": "^2.88.0",
         "request-promise": "^4.2.5",
         "string-replace-async": "^1.2.1"
+    },
+    "11ty": {
+        "compatibility": ">=0.10.0"
     }
 }


### PR DESCRIPTION
Replaces `peerDependencies` with `11ty.compatibility` to avoid breaking npm install

fixes #17 